### PR TITLE
Basemodel load status fix

### DIFF
--- a/models/BaseModel.php
+++ b/models/BaseModel.php
@@ -338,12 +338,9 @@ class BaseModel extends \lithium\data\Model {
 			$key = ((strlen($id) == 24) && (ctype_xdigit($id)))
 				? $self::key()
 				: 'slug';
-			$options['conditions'] = array($key => $id);
+			$options['conditions'] = array($key => $id, 'status' => $status);
 			$result = $self::find('first', $options);
 			if (!$result) {
-				return false;
-			}
-			if (!in_array($result->status, (array) $status)) {
 				return false;
 			}
 			if (!empty($result->deleted)) {


### PR DESCRIPTION
use status in db-query, because we get only one result back, which may not be active. This will then be discarded because status has wrong value and the correct one in the db will not be loaded. needed, because the slug is not unique.
