### PR TITLE
date_time handlebars helper added

### DIFF
--- a/extensions/helper/Handlebars.php
+++ b/extensions/helper/Handlebars.php
@@ -146,5 +146,9 @@ class Handlebars extends \lithium\template\Helper {
 			}
 			return $context->scaffold->$c;
 		});
+		$this->addHelper('date_time', function($a, $b, $c, $d) use ($context) {
+			list($format, $field) = str_getcsv($c, ' ');
+			return date((defined($format)) ? constant($format) : $format, $b->get($field));
+		});
 	}
 }


### PR DESCRIPTION
Added a new helper to make different dateTime formats within Handlebars tags possible.
Examples:

```
{{{date_time DATE_RFC850 valid_from.sec}}}
{{{date_time "Y-m-d H:i:s" valid_from.sec}}}
```
