### PR TITLE
fixed broken header-element in firefox

### DIFF
--- a/webroot/css/ark.css
+++ b/webroot/css/ark.css
@@ -1464,6 +1464,11 @@ body.fixed_header .wrapper.container .navbar-default.navbar-main {
 .sidebar .nav .menu.open .submenu {
   display: block;
 }
+
+.header {
+  overflow: hidden;
+}
+
 .header:before,
 .header:after {
   content: " ";


### PR DESCRIPTION
This fix is used for a better displaying in firefox-browsers.
Since your implementation of the ability to filter data, this new box get out of alignment in firefox.
